### PR TITLE
Fix for MSVC 15.4

### DIFF
--- a/include/named_tuple.h
+++ b/include/named_tuple.h
@@ -5,8 +5,8 @@
 
 #define NAMED_TUPLE_MEMBER(name, expr)                 \
   std::make_pair(                                      \
-      [](const auto& base, const auto& index) {        \
-        using base_t = std::decay_t<decltype(base)>;   \
+      [](auto base, const auto& index) {               \
+        using base_t = decltype(base);                 \
         using index_t = std::decay_t<decltype(index)>; \
         struct accessor : public base_t                \
         {                                              \


### PR DESCRIPTION
It seems that the use of std::decay causes a compiler crash here for some reason:
https://developercommunity.visualstudio.com/content/problem/136507/vc-compiler-crashes-with-internal-error-for-this-c.html

I *think* this fix is okay, as the `base` is never actually being used anywhere, and the pass-by-value signature should work everywhere the pass-by-const-ref worked. But I probably overlooked something...